### PR TITLE
Fix print_item for mod with no body

### DIFF
--- a/syntex_syntax/src/print/pprust.rs
+++ b/syntex_syntax/src/print/pprust.rs
@@ -888,10 +888,16 @@ impl<'a> State<'a> {
                 try!(self.head(&visibility_qualified(item.vis,
                                                     "mod")));
                 try!(self.print_ident(item.ident));
-                try!(self.nbsp());
-                try!(self.bopen());
-                try!(self.print_mod(_mod, &item.attrs));
-                try!(self.bclose(item.span));
+                if _mod.items.is_empty() {
+                    try!(word(&mut self.s, ";"));
+                    try!(self.end()); // end inner head-block
+                    try!(self.end()); // end outer head-block
+                } else {
+                    try!(self.nbsp());
+                    try!(self.bopen());
+                    try!(self.print_mod(_mod, &item.attrs));
+                    try!(self.bclose(item.span));
+                }
             }
             ast::ItemForeignMod(ref nmod) => {
                 try!(self.head("extern"));


### PR DESCRIPTION
When generating a `mod` item with no body, ensure print_item doesn't print a
body.
