### PR TITLE
Fix a span bug for binops

### DIFF
--- a/syntex_syntax/src/parse/parser.rs
+++ b/syntex_syntax/src/parse/parser.rs
@@ -2674,9 +2674,9 @@ impl<'a> Parser<'a> {
             // Semi-statement forms are odd. See https://github.com/rust-lang/rust/issues/29071
             return Ok(lhs);
         }
-        let cur_op_span = self.span;
         self.expected_tokens.push(TokenType::Operator);
         while let Some(op) = AssocOp::from_token(&self.token) {
+            let cur_op_span = self.span;
             let restrictions = if op.is_assign_like() {
                 self.restrictions & RESTRICTION_NO_STRUCT_LITERAL
             } else {


### PR DESCRIPTION
Mirrors https://github.com/rust-lang/rust/pull/29807

r? @erickt 

(This is somewhat urgent since it is causing rustfmt to utterly shit the bed whenever it sees >1 binop).
