### PR TITLE
Prevent overflows by increasing  ring buffer size

### DIFF
--- a/syntex_syntax/src/print/pp.rs
+++ b/syntex_syntax/src/print/pp.rs
@@ -163,9 +163,9 @@ pub struct PrintStackElem {
 const SIZE_INFINITY: isize = 0xffff;
 
 pub fn mk_printer<'a>(out: Box<io::Write+'a>, linewidth: usize) -> Printer<'a> {
-    // Yes 3, it makes the ring buffers big enough to never
+    // Yes 10, it makes the ring buffers big enough to never
     // fall behind.
-    let n: usize = 3 * linewidth;
+    let n: usize = 10 * linewidth;
     debug!("mk_printer {}", linewidth);
     let token = vec![Token::Eof; n];
     let size = vec![0; n];

--- a/syntex_syntax/src/print/pp.rs
+++ b/syntex_syntax/src/print/pp.rs
@@ -163,9 +163,9 @@ pub struct PrintStackElem {
 const SIZE_INFINITY: isize = 0xffff;
 
 pub fn mk_printer<'a>(out: Box<io::Write+'a>, linewidth: usize) -> Printer<'a> {
-    // Yes 10, it makes the ring buffers big enough to never
+    // Yes 55, it makes the ring buffers big enough to never
     // fall behind.
-    let n: usize = 10 * linewidth;
+    let n: usize = 55 * linewidth;
     debug!("mk_printer {}", linewidth);
     let token = vec![Token::Eof; n];
     let size = vec![0; n];


### PR DESCRIPTION
Via trial and error, I could verify that all google-api-rs
crates actually build if the ring-buffer is about 3 times
larger than before.

As the code is generated, some types are massive, and there
is more complexity than in hand-written code.

Increasing the buffer size should have no disadvantage, neither
to performance, nor on memory requirements.

PS: If merged, it would be nice to get a point-release soon to allow google-apis-rs to build again on stable. Thank you.

---

Related to https://github.com/Byron/google-apis-rs/issues/148,
Fixes https://github.com/serde-rs/syntex/issues/33
Fixes https://github.com/serde-rs/serde/issues/229
Maybe related to https://github.com/Byron/yup-oauth2/issues/16
