### PR TITLE
Revert Vec::resize

### DIFF
--- a/syntex_syntax/src/attr.rs
+++ b/syntex_syntax/src/attr.rs
@@ -41,8 +41,7 @@ pub fn mark_used(attr: &Attribute) {
         let idx = (id / 64) as usize;
         let shift = id % 64;
         if slot.borrow().len() <= idx {
-            let len = slot.borrow().len();
-            slot.borrow_mut().extend((0 .. (idx + 1 - len)).map(|_| 0));
+            slot.borrow_mut().resize(idx + 1, 0);
         }
         slot.borrow_mut()[idx] |= 1 << shift;
     });


### PR DESCRIPTION
Vec::resize was added in 1.5.0. [attr.rs#L44](https://github.com/rust-lang/rust/blob/5b1e914b913e93f0fe182a42c897b759824a5e44/src/libsyntax/attr.rs#L44)
