### PR TITLE
Revert Vec::extend_from_slice

### DIFF
--- a/syntex_syntax/src/ext/quote.rs
+++ b/syntex_syntax/src/ext/quote.rs
@@ -186,7 +186,7 @@ pub mod rt {
                     let mut v = vec![];
                     for (i, x) in self.iter().enumerate() {
                         if i > 0 {
-                            v.extend($sep.iter().cloned());
+                            v.extend_from_slice(&$sep);
                         }
                         v.extend(x.to_tokens(cx));
                     }


### PR DESCRIPTION
Extend_from_slice was added in 1.6.0. [quote.rs#L189](https://github.com/rust-lang/rust/blob/5b1e914b913e93f0fe182a42c897b759824a5e44/src/libsyntax/ext/quote.rs#L189)
