### PR TITLE
Fix pretty printing tuple struct element attributes

### DIFF
--- a/syntex_syntax/src/print/pprust.rs
+++ b/syntex_syntax/src/print/pprust.rs
@@ -1403,8 +1403,9 @@ impl<'a> State<'a> {
                 try!(self.commasep(
                     Inconsistent, struct_def.fields(),
                     |s, field| {
-                        try!(s.print_visibility(&field.vis));
                         try!(s.maybe_print_comment(field.span.lo));
+                        try!(s.print_outer_attributes(&field.attrs));
+                        try!(s.print_visibility(&field.vis));
                         s.print_type(&field.ty)
                     }
                 ));


### PR DESCRIPTION
This backports https://github.com/rust-lang/rust/pull/34310, which has not yet landed in a nightly yet, so we can't yet sync with the upstream libsyntax.
