### PR TITLE
Add syntex::with_extra_stack helper

### DIFF
--- a/syntex/src/lib.rs
+++ b/syntex/src/lib.rs
@@ -27,6 +27,9 @@ use syntex_syntax::ptr::P;
 mod error;
 pub use error::Error;
 
+mod stack;
+pub use stack::with_extra_stack;
+
 pub type Pass = fn(ast::Crate) -> ast::Crate;
 
 pub struct Registry {

--- a/syntex/src/stack.rs
+++ b/syntex/src/stack.rs
@@ -12,7 +12,7 @@ const EXTRA_STACK: &'static str = "16777216"; // 16 MB
 /// The Rust parser uses a lot of stack space so codegen sometimes requires more
 /// than is available by default.
 ///
-/// ```
+/// ```rust,ignore
 /// syntex::with_extra_stack(move || {
 ///     let mut reg = syntex::Registry::new();
 ///     reg.add_decorator(/* ... */);

--- a/syntex/src/stack.rs
+++ b/syntex/src/stack.rs
@@ -1,0 +1,63 @@
+use std::env;
+use std::ffi::OsStr;
+use std::ops::Drop;
+use std::thread;
+
+const STACK_ENV_VAR: &'static str = "RUST_MIN_STACK";
+const EXTRA_STACK: &'static str = "16777216"; // 16 MB
+
+/// Runs a function in a thread with extra stack space (16 MB or
+/// `$RUST_MIN_STACK` if set).
+///
+/// The Rust parser uses a lot of stack space so codegen sometimes requires more
+/// than is available by default.
+///
+/// ```
+/// syntex::with_extra_stack(move || {
+///     let mut reg = syntex::Registry::new();
+///     reg.add_decorator(/* ... */);
+///     reg.expand("", src, dst)
+/// })
+/// ```
+///
+/// This function runs with a 16 MB stack by default but a different value can
+/// be set by the RUST_MIN_STACK environment variable.
+pub fn with_extra_stack<F, T>(f: F) -> T
+    where F: Send + 'static + FnOnce() -> T,
+          T: Send + 'static
+{
+    let _tmp_env = set_if_unset(STACK_ENV_VAR, EXTRA_STACK);
+
+    thread::spawn(f).join().unwrap()
+}
+
+fn set_if_unset<K, V>(k: K, v: V) -> TmpEnv<K>
+    where K: AsRef<OsStr>,
+          V: AsRef<OsStr>,
+{
+    match env::var(&k) {
+        Ok(_) => TmpEnv::WasAlreadySet,
+        Err(_) => {
+            env::set_var(&k, v);
+            TmpEnv::WasNotSet(k)
+        }
+    }
+}
+
+#[must_use]
+enum TmpEnv<K>
+    where K: AsRef<OsStr>,
+{
+    WasAlreadySet,
+    WasNotSet(K),
+}
+
+impl<K> Drop for TmpEnv<K>
+    where K: AsRef<OsStr>,
+{
+    fn drop(&mut self) {
+        if let TmpEnv::WasNotSet(ref k) = *self {
+            env::remove_var(k);
+        }
+    }
+}


### PR DESCRIPTION
This is the same workaround from https://github.com/serde-rs/serde/pull/503. I am adding it here because Servo just hit this with quasi_codegen (https://github.com/servo/rust-bindgen/issues/35) and I want to share the code. I will update the serde_codegen implementation to use this too.

Unfortunately we can't apply this to `syntex::Registry::expand` in general because rustc overflows its stack trying to decide whether `syntex::Registry` implements Send :panda_face:.
