### PR TITLE
type renames MacroLoader -> Resolver, DummyMacroLoader -> DummyResolver

### DIFF
--- a/syntex/src/lib.rs
+++ b/syntex/src/lib.rs
@@ -10,7 +10,7 @@ use syntex_syntax::attr;
 use syntex_syntax::codemap::{DUMMY_SP, respan};
 use syntex_syntax::ext::base::{
     IdentMacroExpander,
-    MacroLoader,
+    Resolver,
     MultiItemDecorator,
     MultiItemModifier,
     NamedSyntaxExtension,
@@ -41,19 +41,19 @@ pub struct Registry {
     attrs: Vec<ast::Attribute>,
 }
 
-struct SyntexMacroLoader {
+struct SyntexResolver {
     macros: Vec<ast::MacroDef>,
 }
 
-impl SyntexMacroLoader {
+impl SyntexResolver {
     fn new(macros: Vec<ast::MacroDef>) -> Self {
-        SyntexMacroLoader {
+        SyntexResolver {
             macros: macros
         }
     }
 }
 
-impl MacroLoader for SyntexMacroLoader {
+impl Resolver for SyntexResolver {
     fn load_crate(&mut self, _extern_crate: &ast::Item, _allows_macros: bool) -> Vec<ast::MacroDef> {
         self.macros.clone()
     }
@@ -221,7 +221,7 @@ impl Registry {
         ecfg.features = Some(&features);
 
         let cfg = Vec::new();
-        let mut macro_loader = SyntexMacroLoader::new(self.macros.clone());
+        let mut macro_loader = SyntexResolver::new(self.macros.clone());
         let mut ecx = ExtCtxt::new(&sess, cfg, ecfg, &mut macro_loader);
 
         let krate = expand::expand_crate(&mut ecx, self.syntax_exts, krate);

--- a/syntex_syntax/src/ext/base.rs
+++ b/syntex_syntax/src/ext/base.rs
@@ -583,12 +583,12 @@ fn initial_syntax_expander_table<'feat>(ecfg: &expand::ExpansionConfig<'feat>)
     syntax_expanders
 }
 
-pub trait MacroLoader {
+pub trait Resolver {
     fn load_crate(&mut self, extern_crate: &ast::Item, allows_macros: bool) -> Vec<ast::MacroDef>;
 }
 
-pub struct DummyMacroLoader;
-impl MacroLoader for DummyMacroLoader {
+pub struct DummyResolver;
+impl Resolver for DummyResolver {
     fn load_crate(&mut self, _: &ast::Item, _: bool) -> Vec<ast::MacroDef> {
         Vec::new()
     }
@@ -603,7 +603,7 @@ pub struct ExtCtxt<'a> {
     pub backtrace: ExpnId,
     pub ecfg: expand::ExpansionConfig<'a>,
     pub crate_root: Option<&'static str>,
-    pub loader: &'a mut MacroLoader,
+    pub loader: &'a mut Resolver,
 
     pub mod_path: Vec<ast::Ident> ,
     pub exported_macros: Vec<ast::MacroDef>,
@@ -619,7 +619,7 @@ pub struct ExtCtxt<'a> {
 impl<'a> ExtCtxt<'a> {
     pub fn new(parse_sess: &'a parse::ParseSess, cfg: ast::CrateConfig,
                ecfg: expand::ExpansionConfig<'a>,
-               loader: &'a mut MacroLoader)
+               loader: &'a mut Resolver)
                -> ExtCtxt<'a> {
         let env = initial_syntax_expander_table(&ecfg);
         ExtCtxt {

--- a/syntex_syntax/src/ext/expand.rs
+++ b/syntex_syntax/src/ext/expand.rs
@@ -725,7 +725,7 @@ fn mark_tts(tts: &[TokenTree], m: Mark) -> Vec<TokenTree> {
 mod tests {
     use super::{expand_crate, ExpansionConfig};
     use ast;
-    use ext::base::{ExtCtxt, DummyMacroLoader};
+    use ext::base::{ExtCtxt, DummyResolver};
     use parse;
     use util::parser_testing::{string_to_parser};
     use visit;
@@ -766,7 +766,7 @@ mod tests {
             src,
             Vec::new(), &sess).unwrap();
         // should fail:
-        let mut loader = DummyMacroLoader;
+        let mut loader = DummyResolver;
         let mut ecx = ExtCtxt::new(&sess, vec![], test_ecfg(), &mut loader);
         expand_crate(&mut ecx, vec![], crate_ast);
     }
@@ -781,7 +781,7 @@ mod tests {
             "<test>".to_string(),
             src,
             Vec::new(), &sess).unwrap();
-        let mut loader = DummyMacroLoader;
+        let mut loader = DummyResolver;
         let mut ecx = ExtCtxt::new(&sess, vec![], test_ecfg(), &mut loader);
         expand_crate(&mut ecx, vec![], crate_ast);
     }
@@ -795,7 +795,7 @@ mod tests {
             "<test>".to_string(),
             src,
             Vec::new(), &sess).unwrap();
-        let mut loader = DummyMacroLoader;
+        let mut loader = DummyResolver;
         let mut ecx = ExtCtxt::new(&sess, vec![], test_ecfg(), &mut loader);
         expand_crate(&mut ecx, vec![], crate_ast);
     }
@@ -804,7 +804,7 @@ mod tests {
         let ps = parse::ParseSess::new();
         let crate_ast = panictry!(string_to_parser(&ps, crate_str).parse_crate_mod());
         // the cfg argument actually does matter, here...
-        let mut loader = DummyMacroLoader;
+        let mut loader = DummyResolver;
         let mut ecx = ExtCtxt::new(&ps, vec![], test_ecfg(), &mut loader);
         expand_crate(&mut ecx, vec![], crate_ast)
     }

--- a/syntex_syntax/src/test.rs
+++ b/syntex_syntax/src/test.rs
@@ -28,7 +28,7 @@ use errors;
 use errors::snippet::{SnippetData};
 use config;
 use entry::{self, EntryPointType};
-use ext::base::{ExtCtxt, DummyMacroLoader};
+use ext::base::{ExtCtxt, DummyResolver};
 use ext::build::AstBuilder;
 use ext::expand::ExpansionConfig;
 use fold::Folder;
@@ -276,7 +276,7 @@ fn generate_test_harness(sess: &ParseSess,
     let mut cleaner = EntryPointCleaner { depth: 0 };
     let krate = cleaner.fold_crate(krate);
 
-    let mut loader = DummyMacroLoader;
+    let mut loader = DummyResolver;
     let mut cx: TestCtxt = TestCtxt {
         sess: sess,
         span_diagnostic: sd,


### PR DESCRIPTION
done to follow latest changes in nightly rust.

This change was done to fix aster compilation error on nightly 2016-09-15
