### PR TITLE
Hack around reusing node ids; ignore unknown ty macros

### DIFF
--- a/syntex/src/resolver.rs
+++ b/syntex/src/resolver.rs
@@ -19,7 +19,6 @@ pub struct Resolver<'a> {
     session: &'a ParseSess,
     extensions: HashMap<ast::Name, Rc<SyntaxExtension>>,
     derive_modes: HashMap<ast::Name, Rc<MultiItemModifier>>,
-    next_node_id: ast::NodeId,
 }
 
 impl<'a> Resolver<'a> {
@@ -28,23 +27,13 @@ impl<'a> Resolver<'a> {
             session: session,
             extensions: HashMap::new(),
             derive_modes: HashMap::new(),
-            next_node_id: ast::NodeId::new(1),
         }
     }
 }
 
 impl<'a> base::Resolver for Resolver<'a> {
     fn next_node_id(&mut self) -> ast::NodeId {
-        let id = self.next_node_id;
-
-        match self.next_node_id.as_usize().checked_add(1) {
-            Some(next) => {
-                self.next_node_id = ast::NodeId::new(next);
-            }
-            None => panic!("Input too large, ran out of node ids!")
-        }
-
-        id
+        ast::DUMMY_NODE_ID
     }
     fn get_module_scope(&mut self, _id: ast::NodeId) -> Mark { Mark::root() }
 

--- a/syntex_syntax/src/ext/expand.rs
+++ b/syntex_syntax/src/ext/expand.rs
@@ -868,8 +868,15 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
         };
 
         match ty.node {
-            ast::TyKind::Mac(mac) =>
-                self.collect_bang(mac, Vec::new(), ty.span, ExpansionKind::Ty).make_ty(),
+            ast::TyKind::Mac(mac) => {
+                // FIXME(syntex): ignore unknown macros
+                if self.cx.resolver.find_mac(self.cx.current_expansion.mark, &mac).is_none() {
+                    let ty = ast::Ty { node: ast::TyKind::Mac(mac), .. ty };
+                    return noop_fold_ty(P(ty), self);
+                }
+
+                self.collect_bang(mac, Vec::new(), ty.span, ExpansionKind::Ty).make_ty()
+            }
             _ => unreachable!(),
         }
     }

--- a/syntex_syntax/src/ext/expand.rs
+++ b/syntex_syntax/src/ext/expand.rs
@@ -639,8 +639,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
         if let ast::ExprKind::Mac(mac) = expr.node {
             // FIXME(syntex): ignore unknown macros
             if self.cx.resolver.find_mac(self.cx.current_expansion.mark, &mac).is_none() {
-                let expr = ast::Expr { node: ast::ExprKind::Mac(mac), .. expr };
-                return P(noop_fold_expr(expr, self));
+                return P(ast::Expr { node: ast::ExprKind::Mac(mac), .. expr });
             }
 
             self.collect_bang(mac, expr.attrs.into(), expr.span, ExpansionKind::Expr).make_expr()
@@ -656,8 +655,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
         if let ast::ExprKind::Mac(mac) = expr.node {
             // FIXME(syntex): ignore unknown macros
             if self.cx.resolver.find_mac(self.cx.current_expansion.mark, &mac).is_none() {
-                let expr = ast::Expr { node: ast::ExprKind::Mac(mac), .. expr };
-                return Some(P(noop_fold_expr(expr, self)));
+                return Some(P(ast::Expr { node: ast::ExprKind::Mac(mac), .. expr }));
             }
 
             self.collect_bang(mac, expr.attrs.into(), expr.span, ExpansionKind::OptExpr)
@@ -677,8 +675,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
             PatKind::Mac(mac) => {
                 // FIXME(syntex): ignore unknown macros
                 if self.cx.resolver.find_mac(self.cx.current_expansion.mark, &mac).is_none() {
-                    let pat = ast::Pat { node: PatKind::Mac(mac), .. pat };
-                    return noop_fold_pat(P(pat), self);
+                    return P(ast::Pat { node: PatKind::Mac(mac), .. pat });
                 }
 
                 self.collect_bang(mac, Vec::new(), pat.span, ExpansionKind::Pat).make_pat()
@@ -753,7 +750,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                         // FIXME(syntex): ignore unknown macros
                         if self.cx.resolver.find_mac(self.cx.current_expansion.mark, &mac).is_none() {
                             let item = ast::Item { node: ItemKind::Mac(mac), .. item };
-                            return noop_fold_item(P(item), self);
+                            return SmallVector::one(P(item));
                         }
 
                         self.collect(ExpansionKind::Items, InvocationKind::Bang {
@@ -826,8 +823,8 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
             ast::TraitItemKind::Macro(mac) => {
                 // FIXME(syntex): ignore unknown macros
                 if self.cx.resolver.find_mac(self.cx.current_expansion.mark, &mac).is_none() {
-                    let item = ast::TraitItem{ node: ast::TraitItemKind::Macro(mac), .. item };
-                    return noop_fold_trait_item(item, self);
+                    let item = ast::TraitItem { node: ast::TraitItemKind::Macro(mac), .. item };
+                    return SmallVector::one(item);
                 }
 
                 let ast::TraitItem { attrs, span, .. } = item;
@@ -851,7 +848,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
                 // FIXME(syntex): ignore unknown macros
                 if self.cx.resolver.find_mac(self.cx.current_expansion.mark, &mac).is_none() {
                     let item = ast::ImplItem { node: ast::ImplItemKind::Macro(mac), .. item };
-                    return noop_fold_impl_item(item, self);
+                    return SmallVector::one(item);
                 }
 
                 let ast::ImplItem { attrs, span, .. } = item;
@@ -871,8 +868,7 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
             ast::TyKind::Mac(mac) => {
                 // FIXME(syntex): ignore unknown macros
                 if self.cx.resolver.find_mac(self.cx.current_expansion.mark, &mac).is_none() {
-                    let ty = ast::Ty { node: ast::TyKind::Mac(mac), .. ty };
-                    return noop_fold_ty(P(ty), self);
+                    return P(ast::Ty { node: ast::TyKind::Mac(mac), .. ty });
                 }
 
                 self.collect_bang(mac, Vec::new(), ty.span, ExpansionKind::Ty).make_ty()
@@ -887,11 +883,6 @@ impl<'a, 'b> Folder for InvocationCollector<'a, 'b> {
 
     fn fold_item_kind(&mut self, item: ast::ItemKind) -> ast::ItemKind {
         noop_fold_item_kind(self.cfg.configure_item_kind(item), self)
-    }
-
-    // FIXME(syntex): ignore unknown macros
-    fn fold_mac(&mut self, mac: ast::Mac) -> ast::Mac {
-        noop_fold_mac(mac, self)
     }
 
     fn new_id(&mut self, id: ast::NodeId) -> ast::NodeId {


### PR DESCRIPTION
This PR hacks around an odd bug in syntex due to the new way macros are expanded. The new algorithm works (as far as I can tell) by doing a pass through the AST and pulling out all the macro calls into a series of macro invocations, with the original AST being replaced with a placeholder AST. These invocations then are recursively expanded and substituted back into the AST.

The bug stems from how we know where to splice in the new AST. This is done by building a mapping of node ids of the AST to expand to the actual macro. It seems we're somehow the node ids generated by the resolver are colliding with the hygiene system's `Mark::fresh()`, which is being used as the placeholder's node id. When we're trying to substitute the newly expanded macros, we end up generating bad code by substituting in the wrong place.

This hack makes sure that the node ids are globally unique, but given that rustc doesn't seem to have a problem, I feel this is just obscuring the real bug.

@nrc, @jseyfried, @cgswords: any of you know how rustc avoids this problem?

Also, this also adds the ability to ignore unknown type macros, which was accidentally left out of 0.45.0.

cc @korczis
