### PR TITLE
Get 0.29.x to compile on latest nightly

### DIFF
--- a/syntex_syntax/Cargo.toml
+++ b/syntex_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntex_syntax"
-version = "0.29.1"
+version = "0.29.3"
 authors = [ "erick.tryzelaar@gmail.com" ]
 license = "MIT/Apache-2.0"
 description = "Export of libsyntax for code generation"

--- a/syntex_syntax/src/attr.rs
+++ b/syntex_syntax/src/attr.rs
@@ -818,8 +818,8 @@ pub type ThinAttributes = Option<Box<Vec<Attribute>>>;
 pub trait ThinAttributesExt {
     fn map_thin_attrs<F>(self, f: F) -> Self
         where F: FnOnce(Vec<Attribute>) -> Vec<Attribute>;
-    fn prepend(mut self, attrs: Self) -> Self;
-    fn append(mut self, attrs: Self) -> Self;
+    fn prepend(self, attrs: Self) -> Self;
+    fn append(self, attrs: Self) -> Self;
     fn update<F>(&mut self, f: F)
         where Self: Sized,
               F: FnOnce(Self) -> Self;

--- a/syntex_syntax/src/errors/mod.rs
+++ b/syntex_syntax/src/errors/mod.rs
@@ -19,7 +19,6 @@ use errors::emitter::{Emitter, EmitterWriter};
 
 use std::cell::{RefCell, Cell};
 use std::{error, fmt};
-use std::io::prelude::*;
 use std::rc::Rc;
 use term;
 
@@ -644,8 +643,6 @@ pub enum Level {
 
 impl fmt::Display for Level {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::fmt::Display;
-
         self.to_str().fmt(f)
     }
 }

--- a/syntex_syntax/src/ext/quote.rs
+++ b/syntex_syntax/src/ext/quote.rs
@@ -414,7 +414,7 @@ pub fn expand_quote_expr<'cx>(cx: &'cx mut ExtCtxt,
     base::MacEager::expr(expanded)
 }
 
-pub fn expand_quote_item<'cx>(cx: &mut ExtCtxt,
+pub fn expand_quote_item<'cx>(cx: &'cx mut ExtCtxt,
                               sp: Span,
                               tts: &[TokenTree])
                               -> Box<base::MacResult+'cx> {

--- a/syntex_syntax/src/parse/mod.rs
+++ b/syntex_syntax/src/parse/mod.rs
@@ -19,7 +19,6 @@ use ptr::P;
 use str::char_at;
 
 use std::cell::RefCell;
-use std::io::Read;
 use std::iter;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;

--- a/syntex_syntax/src/parse/parser.rs
+++ b/syntex_syntax/src/parse/parser.rs
@@ -62,7 +62,6 @@ use ptr::P;
 use parse::PResult;
 
 use std::collections::HashSet;
-use std::io::prelude::*;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;

--- a/syntex_syntax/src/util/interner.rs
+++ b/syntex_syntax/src/util/interner.rs
@@ -115,14 +115,12 @@ impl Ord for RcStr {
 
 impl fmt::Debug for RcStr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::fmt::Debug;
         self[..].fmt(f)
     }
 }
 
 impl fmt::Display for RcStr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::fmt::Display;
         self[..].fmt(f)
     }
 }


### PR DESCRIPTION
@nikomatsakis has fixed a [soundness bug](https://github.com/rust-lang/rust/pull/38897#issuecomment-271390139) that is causing 0.29.x to fail. There are a few dependencies that are still on serde 0.6 / syntex 0.29.x, so this backports the fix in order to get the crater run to pass.